### PR TITLE
Document plugin add/remove/upgrade

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,3 +33,12 @@ To update the version of the underlying plugins run the following commands:
 
     cd ~/.config/nvim
     nvim -c 'lua require("rwjblue.plugins").update()'
+
+Rollback
+========
+
+If, after an update, you determine that you would like to rollback to a prior
+checkout of plugins you would do the following:
+
+    cd ~/.config/nvim
+    nvim --headless -c 'lua require("rwjblue.plugins").rollback()'

--- a/README.md
+++ b/README.md
@@ -42,3 +42,13 @@ checkout of plugins you would do the following:
 
     cd ~/.config/nvim
     nvim --headless -c 'lua require("rwjblue.plugins").rollback()'
+
+New Plugins
+===========
+
+When you want to add a new plugin (leaving the rest of the plugins at their
+existing versions), add it to the `packer.startup` section of
+`lua/rwjblue/plugins.lua` then run:
+
+    cd ~/.config/nvim
+    nvim --headless -c 'lua require("rwjblue.plugins").install()'

--- a/lua/rwjblue/plugins.lua
+++ b/lua/rwjblue/plugins.lua
@@ -114,9 +114,6 @@ packer.startup({
       end,
     }
   end,
-  config = {
-    snapshot = snapshot_path,
-  }
 })
 
 function M.take_snapshot(opts)
@@ -175,7 +172,7 @@ function M.bootstrap(opts)
   end
 
   -- install from plugins-dev.json lockfile
-  packer.install()
+  packer.rollback(snapshot_path)
 end
 
 return M


### PR DESCRIPTION

## Upgrading

Upgrading is also very simple.

To update the configuration itself you just need to pull the latest commits:

    cd ~/.config/nvim
    git pull origin master

To update the version of the underlying plugins run the following commands:

    cd ~/.config/nvim
    nvim -c 'lua require("rwjblue.plugins").update()'

## Rollback

If, after an update, you determine that you would like to rollback to a prior
checkout of plugins you would do the following:

    cd ~/.config/nvim
    nvim --headless -c 'lua require("rwjblue.plugins").rollback()'

## New Plugins

When you want to add a new plugin (leaving the rest of the plugins at their
existing versions), add it to the `packer.startup` section of
`lua/rwjblue/plugins.lua` then run:

    cd ~/.config/nvim
    nvim --headless -c 'lua require("rwjblue.plugins").install()'
